### PR TITLE
feat: support nonce for inline script

### DIFF
--- a/server.d.ts
+++ b/server.d.ts
@@ -1,1 +1,1 @@
-declare export function injectRSCPayload(rscStream: ReadableStream): TransformStream;
+declare export function injectRSCPayload(rscStream: ReadableStream, nonce?: string): TransformStream;

--- a/server.d.ts
+++ b/server.d.ts
@@ -1,1 +1,1 @@
-declare export function injectRSCPayload(rscStream: ReadableStream, nonce?: string): TransformStream;
+declare export function injectRSCPayload(rscStream: ReadableStream, options?: { nonce?: string }): TransformStream;

--- a/server.js
+++ b/server.js
@@ -1,11 +1,12 @@
 const encoder = new TextEncoder();
 const trailer = '</body></html>';
 
-export function injectRSCPayload(rscStream, nonce) {
+export function injectRSCPayload(rscStream, options) {
   let decoder = new TextDecoder();
   let resolveFlightDataPromise;
   let flightDataPromise = new Promise((resolve) => resolveFlightDataPromise = resolve);
   let startedRSC = false;
+  let nonce = options && typeof options.nonce === 'string' ? options.nonce : undefined;
 
   // Buffer all HTML chunks enqueued during the current tick of the event loop (roughly)
   // and write them to the output stream all at once. This ensures that we don't generate

--- a/test.js
+++ b/test.js
@@ -99,7 +99,7 @@ test('should support nonce', async () => {
   let html = testStream(['<html><body><h1>Test</h1>', '<p>Hello world</p></body></html>']);
   let rscStream = testStream(['foo bar']);
   let nonce = "test";
-  let injected = html.pipeThrough(injectRSCPayload(rscStream, nonce));
+  let injected = html.pipeThrough(injectRSCPayload(rscStream, { nonce }));
 
   let result = await streamToString(injected);
   assert.equal(result, '<html><body><h1>Test</h1><p>Hello world</p><script nonce="test">(self.__FLIGHT_DATA||=[]).push("foo bar")</script></body></html>');

--- a/test.js
+++ b/test.js
@@ -25,8 +25,8 @@ function testStream(chunks, ref) {
   });
 }
 
-function runScripts(html) {
-  let scripts = html.matchAll(/<script>(.*?)<\/script>/g);
+function runScripts(html, nonce) {
+  let scripts = html.matchAll(new RegExp(`<script${nonce ? ` nonce="${nonce}"` : ''}>(.*?)<\/script>`, 'g'));
   let window = {};
   let ctx = vm.createContext({self: window, window, TextEncoder, ReadableStream, atob});
   for (let script of scripts) {
@@ -94,3 +94,17 @@ test('should handle chunked data', async () => {
   let decoded = await streamToString(clientStream);
   assert.equal(decoded, 'foo barbaz quxabcdef');
 });
+
+test('should support nonce', async () => {
+  let html = testStream(['<html><body><h1>Test</h1>', '<p>Hello world</p></body></html>']);
+  let rscStream = testStream(['foo bar']);
+  let nonce = "test";
+  let injected = html.pipeThrough(injectRSCPayload(rscStream, nonce));
+
+  let result = await streamToString(injected);
+  assert.equal(result, '<html><body><h1>Test</h1><p>Hello world</p><script nonce="test">(self.__FLIGHT_DATA||=[]).push("foo bar")</script></body></html>');
+
+  let clientStream = runScripts(result, nonce);
+  let decoded = await streamToString(clientStream);
+  assert.equal(decoded, 'foo bar');
+})


### PR DESCRIPTION
Hi! Thanks for providing a very handy utility for RSC. This PR adds `nonce` option for `injectRSCPayload`. This option is intended to be used along with React SSR's `nonce` option. Here is an example based on the readme usage:

```js
import {createFromReadableStream} from 'react-server-dom-BUNDLER/client.edge';
import {renderToReadableStream as renderHTMLToReadableStream} from 'react-dom/server.edge';
import {injectRSCPayload} from 'rsc-html-stream/server';

let nonce = crypto.randomUUID()

let [s1, s2] = rscStream.tee();
let data;
function Content() {
  data ??= createFromReadableStream(s1, {
   nonce // 👈 for prepare destination link
  }); 
  return React.use(data);
}

let htmlStream = await renderHTMLToReadableStream(<Content />, {
  nonce  // 👈 for ssr streaming inline scripts and bootstrap scripts
});

let responseStream = htmlStream.pipeThrough(
  injectRSCPayload(s2, { nonce }) // 👈 for __FLIGHT_DATA inline scripts
); 

new Response(responseStream, {
  headers: {
    'Content-Security-Policy': `script-src 'nonce-${nonce}';`, //  👈 CSP setup
  },
});
```